### PR TITLE
fix: 修复 system_proxy() 可能误取 NO_PROXY 值的问题

### DIFF
--- a/src/common/util/requests_util.py
+++ b/src/common/util/requests_util.py
@@ -30,12 +30,14 @@ class ProxyBuilder:
         if len(proxies) == 0:
             return {}
 
-        # extract ip and port from proxies dict
-        addr: str = proxies.popitem()[1]
+        # 优先使用 http 或 https 代理
+        addr = proxies.get('http') or proxies.get('https')
+        if addr is None:
+            return {}
+
         prot = '://'
-        index = addr.find(prot)
         if prot in addr:
-            addr = addr[index + len(prot):]
+            addr = addr[addr.find(prot) + len(prot):]
 
         return cls.build_proxy(addr)
 


### PR DESCRIPTION
在部署依赖jmcomic库相关项目时，环境变量中存在NO_PROXY的话，getproxies() 返回的字典中会包含 'no' 键，popitem可能就会取到no键的值，比如：

```
{'http': 'http://127.0.0.1:7890', 'no': 'localhost,127.0.0.1,::1'}
```

传入curl_cffi就会报错提示不支持的代理格式，我改为了显式获取http或https代理地址